### PR TITLE
fix bug: exchange output of 'Multicollinerity Terms' and 'Method' in …

### DIFF
--- a/R/stepwiseCox.R
+++ b/R/stepwiseCox.R
@@ -149,8 +149,8 @@ stepwiseCox <- function(formula,
                   "Select Criterion = ",
                   "Entry Significance Level(sle) = ",
                   "Stay Significance Level(sls) = ",
-                  "Multicollinearity Terms = ",
-                  "Method = ")
+                  "Method = ",
+                  "Multicollinearity Terms = ")
   if(select=="SL"){
     if(selection=="forward"){
       ModInf <- ModInf[-6,]


### PR DESCRIPTION
…'Basic Information' of stepwiseCox()